### PR TITLE
Plusplus people

### DIFF
--- a/scripts/plusplus.coffee
+++ b/scripts/plusplus.coffee
@@ -50,13 +50,13 @@ class ScoreKeeper
     for user_jid, user of @robot.brain.data.users
       if user.mention_name == mentionName
         return user.name
-    return mentionName
+    return ""
 
   findMentionNameByUser: (user_name) ->
     for user_jid, user of @robot.brain.data.users
       if user.name == user_name
         return user.mention_name
-    return "Could not find: #{user_name}."
+    return ""
 
   setMentionName: (user_name, mention_name) ->
     user = @robot.brain.userForName(user_name)
@@ -65,6 +65,8 @@ class ScoreKeeper
   add: (user, from) ->
     if @validate(user, from)
       user = @getUser(user)
+      if user == ""
+        return
       @cache.scores[user]++
       @saveUser(user, from)
 
@@ -103,7 +105,7 @@ class ScoreKeeper
     messageIsSpam
 
   validate: (user, from) ->
-    user != from && user != "" && !@isSpam(user, from)
+    user != from && user != "" && !@isSpam(user, from) && findMentionNameByUser(from.name) != ""
 
   length: () ->
     @cache.scoreLog.length

--- a/scripts/plusplus.coffee
+++ b/scripts/plusplus.coffee
@@ -56,7 +56,7 @@ class ScoreKeeper
     for user_jid, user of @robot.brain.data.users
       if user.name == user_name
         return user.mention_name
-    return ""
+    return user_name
 
   setMentionName: (user_name, mention_name) ->
     user = @robot.brain.userForName(user_name)
@@ -105,7 +105,7 @@ class ScoreKeeper
     messageIsSpam
 
   validate: (user, from) ->
-    user != from && user != "" && !@isSpam(user, from) && findMentionNameByUser(from.name) != ""
+    user != from && user != "" && !@isSpam(user, from) && user.email != ""
 
   length: () ->
     @cache.scoreLog.length


### PR DESCRIPTION
It's pretty clear that points have become a serious problem of late. The combination of bots giving out points and people giving points to team names has left the point system devoid of all value. More importantly, points aren't fun anymore. These changes implement a couple of policy improvements.

1. Only people can give out points. If a user doesn't have an at mention  name, then that user cannot give points.
2. Only people can receive points. No more (taft)++